### PR TITLE
Update privacy policy: clarify local-only data processing

### DIFF
--- a/content/mentions-legales.md
+++ b/content/mentions-legales.md
@@ -8,16 +8,15 @@ Le chatbot Owlie ainsi que son site internet sont un projet gratuit et bénévol
 
 Les données partagées avec le chatbot Owlie sont anonymes et ne nécessitent aucune forme d'identification de l'utilisateur. Le chatbot demande uniquement le nom par lequel l'utilisateur souhaite être appelé pendant la conversation. Ce nom peut être réel ou imaginaire, tout comme toute autre information fournie au chatbot.
 
-Les données échangées avec le chatbot sont stockées sur des serveurs sécurisés, agréés [Hébergement de Données de Santé](https://esante.gouv.fr/labels-certifications/hebergement-des-donnees-de-sante), situés en France. Les données sont chiffrées en transit et au repos.
+Le chatbot Owlie fonctionne entièrement en local, directement dans le navigateur de l'utilisateur. Les conversations ne quittent jamais l'appareil&nbsp;: aucune des données échangées avec le chatbot n'est transmise à des serveurs tiers. En particulier, aucune donnée n'est utilisée pour l'entraînement d'une quelconque intelligence artificielle.
 
 ## Cookies
 
-L'intégralité des cookies stockés par Owlie est nécessaire à son bon fonctionnement&nbsp;:
+Les données stockées par Owlie le sont localement, dans le navigateur de l'utilisateur, et sont nécessaires à son bon fonctionnement&nbsp;:
 - un identifiant anonyme (au format UUID v4) permettant d'assurer la continuité de la conversation
-- données des conversations précédentes pour l'affichage de l'historique d'une session à la suivante
-- un cookie Google Analytics pour l'analyse anonyme des visites des utilisateurs sur le site et le chatbot
+- les données des conversations précédentes pour l'affichage de l'historique d'une session à la suivante
 
-Aucun cookie à destination publicitaire n'est présent sur le site ou le chatbot.
+Ces données ne quittent jamais le navigateur. Aucun cookie à destination publicitaire ou de suivi n'est présent sur le site ou le chatbot.
 
 ## Hébergement du site
 


### PR DESCRIPTION
## Summary
Updated the legal notices and privacy policy to accurately reflect that Owlie operates entirely locally in the user's browser with no server-side data transmission or storage.

## Key Changes
- **Data Storage**: Clarified that the chatbot functions entirely locally in the browser, with no data transmitted to third-party servers
- **Removed outdated claims**: Removed references to secure French servers and HDH certification that no longer apply
- **Cookies/Local Storage**: Reframed the "Cookies" section to describe local browser storage instead, removing mention of Google Analytics
- **Data Usage**: Explicitly stated that no conversation data is used for AI model training
- **Privacy assurance**: Added clarification that no tracking or advertising cookies are present

## Implementation Details
- Changed terminology from "cookies" to "local storage" to more accurately describe browser-based data persistence
- Removed Google Analytics reference entirely
- Emphasized the privacy-first architecture where all data remains on the user's device
- Maintained the list of necessary local identifiers (UUID and conversation history) while clarifying their scope

https://claude.ai/code/session_019ccRfFbuCvFds7pJFF7qjR